### PR TITLE
Allow servers to be instatiated directly from net.Listener

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -25,10 +25,11 @@ type Server struct {
 	errs chan error
 }
 
-// New instantiates and returns a new server, bound to the `bind` address given.
-// Semantics for `bind` follow those set forth in the `net` package. Calling
-// `New()` does in-fact create a TCP Listener on that address, and returns an
-// error if the address is non-parsable, or the network is not able to be bound.
+// NewBound instantiates and returns a new server, bound to the `bind` address
+// given. Semantics for `bind` follow those set forth in the `net` package.
+// Calling `New()` does in-fact create a TCP Listener on that address, and
+// returns an error if the address is non-parsable, or the network is not
+// able to be bound.
 //
 // Otherwise, a server is returned.
 func New(bind string) (*Server, error) {
@@ -37,11 +38,17 @@ func New(bind string) (*Server, error) {
 		return nil, err
 	}
 
+	return NewSocket(socket), nil
+}
+
+// New instantiates a new RTMP server which listens on
+// the provided network socket.
+func NewSocket(socket net.Listener) *Server {
 	return &Server{
 		socket:  socket,
 		clients: make(chan *client.Client),
 		errs:    make(chan error),
-	}, nil
+	}
 }
 
 // Close closes the network socket, terminating the processof accepting new

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,16 @@ func TestNewServerConstructsServerWithValidBind(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestServerSocketReturnsNew(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:1935")
+	assert.Nil(t, err)
+
+	s := server.NewSocket(l)
+	defer s.Close()
+
+	assert.IsType(t, &server.Server{}, s)
+}
+
 func TestServerFailsWithInvalidBind(t *testing.T) {
 	s, err := server.New("256.256.256.256:1234")
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/WatchBeam/rtmp/client"
 	"github.com/WatchBeam/rtmp/server"
@@ -21,7 +22,7 @@ func TestServerSocketReturnsNew(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:1935")
 	assert.Nil(t, err)
 
-	s := server.NewSocket(l)
+	s := server.NewSocket(l.(*net.TCPListener))
 	defer s.Close()
 
 	assert.IsType(t, &server.Server{}, s)
@@ -45,4 +46,26 @@ func TestListenGetsNewClients(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.IsType(t, &client.Client{}, <-s.Clients())
+}
+
+func TestReleasesConnection(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:1935")
+	assert.Nil(t, err)
+
+	s := server.NewSocket(l.(*net.TCPListener))
+	defer s.Close()
+
+	acceptReturn := make(chan struct{})
+	go func() {
+		s.Accept()
+		close(acceptReturn)
+	}()
+
+	assert.Equal(t, l, s.Release())
+
+	select {
+	case <-acceptReturn:
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "timeout: xpected to Accept() to have returned when release is called")
+	}
 }


### PR DESCRIPTION
What the title says 😛  This allows servers to be instantiated from existing sockets, such that those that are passed over as fds when the process starts.